### PR TITLE
pypy3 compatibility

### DIFF
--- a/src/ed25519/keys.py
+++ b/src/ed25519/keys.py
@@ -60,13 +60,13 @@ def from_ascii(s_ascii, prefix="", encoding="base64"):
         prefix = prefix.decode('ascii')
     s_ascii = remove_prefix(s_ascii.strip(), prefix)
     if encoding == "base64":
-        s_ascii += "="*((4 - len(s_ascii)%4)%4)
-        s_bytes = base64.b64decode(s_ascii)
+        s_ascii += "=" * ((4 - len(s_ascii) % 4) % 4)
+        s_bytes = base64.b64decode(s_ascii.encode('ascii'))
     elif encoding == "base32":
-        s_ascii += "="*((8 - len(s_ascii)%8)%8)
-        s_bytes = base64.b32decode(s_ascii.upper())
+        s_ascii += "=" * ((8 - len(s_ascii) % 8) % 8)
+        s_bytes = base64.b32decode(s_ascii.upper().encode('ascii'))
     elif encoding in ("base16", "hex"):
-        s_bytes = base64.b16decode(s_ascii.upper())
+        s_bytes = base64.b16decode(s_ascii.upper().encode('ascii'))
     else:
         raise NotImplementedError
     return s_bytes


### PR DESCRIPTION
There was an issue in `from_ascii` which when trying to decode base64 on `unicode` data caused:

```python
Traceback (most recent call last):
  File "test.py", line 1, in <module>
    import ed25519
  File "/Users/miki725/.virtualenvs/pypy3ed25519/site-packages/ed25519/__init__.py", line 1, in <module>
    from .keys import (BadSignatureError, BadPrefixError,
  File "/Users/miki725/.virtualenvs/pypy3ed25519/site-packages/ed25519/keys.py", line 191, in <module>
    selftest()
  File "/Users/miki725/.virtualenvs/pypy3ed25519/site-packages/ed25519/keys.py", line 183, in selftest
    prefix="priv0-", encoding="base64")
  File "/Users/miki725/.virtualenvs/pypy3ed25519/site-packages/ed25519/keys.py", line 82, in __init__
    sk_s = from_ascii(sk_s, encoding=encoding)
  File "/Users/miki725/.virtualenvs/pypy3ed25519/site-packages/ed25519/keys.py", line 64, in from_ascii
    s_bytes = base64.b64decode(s_ascii)
  File "/usr/local/Cellar/pypy3/2.4.0/libexec/lib-python/3/base64.py", line 83, in b64decode
    raise TypeError("expected bytes, not %s" % s.__class__.__name__)
TypeError: expected bytes, not str
```

https://github.com/warner/python-ed25519/commit/b7f418d6d5346cf9e87e3f9182e4b53252b834a3 addresses that.

also this PR includes flake8 fixes in https://github.com/warner/python-ed25519/commit/3c6d4f8656263c226e2058a6d58c6ad491d4f963 (using auto-formatter). If you prefer to merge without flake8, let me know and can submit separate PR fixing flake8.